### PR TITLE
Adds README, description and repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "meson-next"
 version = "1.2.2"
-authors = ["dovee <dovee@users.noreply.github.com>","Brandon Piña"]
-description = "Forked from meson by dovee"
-documentation = "https://docs.rs/meson/1.0.0"
+authors = ["dovee <dovee@users.noreply.github.com>", "Brandon Piña"]
+description = "A build dependency crate for running Meson to build a native library"
+documentation = "https://docs.rs/meson-next/latest/meson_next"
+repository = "https://github.com/ThatNerdUKnow/meson-rs"
 license = "MIT"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meson-next"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["dovee <dovee@users.noreply.github.com>", "Brandon Piña"]
 description = "A build dependency crate for running Meson to build a native library"
 documentation = "https://docs.rs/meson-next/latest/meson_next"

--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ fn main() {
     build_path.join("build");
     let build_path = build_path.to_str().unwrap();
 
+    let mut options = HashMap::new();
+    options.insert("key", "value");
+
+    let config = meson::Config::new().options(options);
+
     println!("cargo:rustc-link-lib=squid");
     println!("cargo:rustc-link-search=native={}", build_path);
-    meson::build("clib", build_path);
+    meson::build("clib", build_path, config);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A build dependency crate for running [Meson](https://mesonbuild.com/index.html) to build a native library.
 
-## Dependencies
-
 This crate is a simple wrapper that invokes the system's meson binary.
 
-Make sure you have both `meson` and `ninja` installed. Refer to [Meson's manual](https://mesonbuild.com/SimpleStart.html) for specific install instructions for your OS.
+Ensure you have both `meson` and `ninja` installed. Refer to [Meson's manual](https://mesonbuild.com/SimpleStart.html) for specific install instructions for your OS.
+
+This crate is a fork of meson 1.0 by dovee, which is abandoned.
 
 ## Build Example
 
@@ -46,7 +46,7 @@ Cargo.toml:
 # ...
 
 [build-dependencies]
-meson = "1.0.0"
+meson-next = "1"
 ```
 
 meson.build:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Rust meson-next crate
+
+A build dependency crate for running [Meson](https://mesonbuild.com/index.html) to build a native library.
+
+## Dependencies
+
+This crate is a simple wrapper that invokes the system's meson binary.
+
+Make sure you have both `meson` and `ninja` installed. Refer to [Meson's manual](https://mesonbuild.com/SimpleStart.html) for specific install instructions for your OS.
+
+## Build Example
+
+```text
+.
+├── build.rs
+├── Cargo.toml
+├── clib
+│   ├── meson.build
+│   ├── squid.h
+│   └── squid.c
+└── src
+    └── lib.rs
+```
+
+build.rs:
+
+```rust
+extern crate meson;
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let build_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    build_path.join("build");
+    let build_path = build_path.to_str().unwrap();
+
+    println!("cargo:rustc-link-lib=squid");
+    println!("cargo:rustc-link-search=native={}", build_path);
+    meson::build("clib", build_path);
+}
+```
+
+Cargo.toml:
+
+```toml
+# ...
+
+[build-dependencies]
+meson = "1.0.0"
+```
+
+meson.build:
+
+```text
+project('squid', 'c')
+shared_library('squid', 'squid.c')
+```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This crate is a fork of meson 1.0 by dovee, which is abandoned.
 build.rs:
 
 ```rust
-extern crate meson;
+extern crate meson_next as meson;
 use std::env;
 use std::path::PathBuf;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! build.rs:
 //!
 //! ```
-//! extern crate meson;
+//! extern crate meson_next as meson;
 //! use std::env;
 //! use std::path::PathBuf;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,15 +18,20 @@
 //! extern crate meson_next as meson;
 //! use std::env;
 //! use std::path::PathBuf;
+//! use std::collections::HashMap;
 //!
 //! fn main() {
 //!     let build_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("build");
 //!     let build_path = build_path.to_str().unwrap();
-//!     let config = meson::Config::new()
+//!
+//!     let mut options = HashMap::new();
+//!     options.insert("key", "value");
+//!
+//!     let config = meson::Config::new().options(options);
 //!
 //!     println!("cargo:rustc-link-lib=squid");
 //!     println!("cargo:rustc-link-search=native={}", build_path);
-//!     meson::build("clib", build_path,config);
+//!     meson::build("clib", build_path, config);
 //! }
 //! ```
 //!
@@ -50,7 +55,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::{env, vec};
 
-use config::Config;
+pub use config::Config;
 pub mod config;
 
 /// Runs meson and/or ninja to build a project.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! # ...
 //!
 //! [build-dependencies]
-//! meson = "1.0.0"
+//! meson-next = "1"
 //! ```
 //!
 //! meson.build:


### PR DESCRIPTION
It would be a good idea to add a description and a README to crates.io, and a link to this repository. If someone searches "meson" there, this one has to rank first or at least a close second.

Accepting this PR would also bump the last update to 2024. Maybe it won't improve the ranking in crates.io, but it would in Google.

EDIT: I also updated the crate name to `meson-next` in the example.